### PR TITLE
Add line-of-sight for enemy mobs (#10)

### DIFF
--- a/Enemies/ForestEnemies/EnemyBee.tscn
+++ b/Enemies/ForestEnemies/EnemyBee.tscn
@@ -29,7 +29,7 @@ animations = [ {
 [node name="AnimatedSprite" type="AnimatedSprite"]
 visible = false
 frames = SubResource( 5 )
-frame = 2
+frame = 1
 speed_scale = 1.2
 playing = true
 centered = false

--- a/Player/Player.tscn
+++ b/Player/Player.tscn
@@ -34,7 +34,7 @@ script = ExtResource( 2 )
 position = Vector2( 16, 16 )
 frames = SubResource( 5 )
 animation = "walk"
-frame = 1
+frame = 3
 speed_scale = 1.5
 playing = true
 


### PR DESCRIPTION
This commit implements a simple field-of-vision implementation. If the player is within the enemy line of sight, then it moves.
Instead of using Area2D etc., I just used high-school geometry to compute if a point (player pos) is within the radius of a circle
(defined by enemy pos and line of sight as radius).