### PR TITLE
Remove Player node at root Game scene

### DIFF
--- a/Game.tscn
+++ b/Game.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://Level/Forest.tscn" type="PackedScene" id=1]
-[ext_resource path="res://Player/Player.tscn" type="PackedScene" id=2]
 [ext_resource path="res://Game.gd" type="Script" id=3]
 [ext_resource path="res://HUD.tscn" type="PackedScene" id=4]
 
@@ -9,8 +8,6 @@
 script = ExtResource( 3 )
 
 [node name="HUD" parent="." instance=ExtResource( 4 )]
-
-[node name="Player" parent="." instance=ExtResource( 2 )]
 
 [node name="Forest" parent="." instance=ExtResource( 1 )]
 


### PR DESCRIPTION
What usually happens is that Player Node already exists, then we load up
another one, causing multiple Player nodes at the same time.

Resolves #36 